### PR TITLE
Bindable test example

### DIFF
--- a/examples/flexjs/DataBindingTestbed/README.txt
+++ b/examples/flexjs/DataBindingTestbed/README.txt
@@ -1,0 +1,51 @@
+﻿////////////////////////////////////////////////////////////////////////////////
+//
+//  Licensed to the Apache Software Foundation (ASF) under one or more
+//  contributor license agreements.  See the NOTICE file distributed with
+//  this work for additional information regarding copyright ownership.
+//  The ASF licenses this file to You under the Apache License, Version 2.0
+//  (the "License"); you may not use this file except in compliance with
+//  the License.  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+DESCRIPTION
+
+The DataBindingTestbed shows a Flex application that is simply a test application
+for a range of Databinding variations. Its primary purpose is to demonstrate to the
+development team examples of bindings that do not currently work or do not work well,
+as well as what currently works, and therefore serves to demonstrate what areas
+require attention for improvements or bugfixes.
+
+This Flex application may be run as a Flash SWF or cross-compiled (using Falcon JX)
+into JavaScript and HTML and run without Flash.
+
+The DataBindingTestbed is primarily for development purposes, but also shows 
+simple examples of a range of binding types that might be useful as examples for
+FlexJS developers to see how things work (or what currently does not work).
+The examples in the code that are commented out are very likely things that need
+attention or fixes. If you encounter any bugs in binding that are not currently
+represented in this example, please contact the dev team via the mailing list 
+   web view : https://lists.apache.org/list.html?dev@flex.apache.org
+  subscribe : dev-subscribe@flex.apache.org
+participate : dev@flex.apache.org
+
+
+COMPONENTS and BEADS
+
+- Container
+- Label
+
+
+NOTES
+
+The cross-compilation to JavaScript often results in non-fatal warnings. Some of these warnings
+should be addressed in future releases of the Falcon JX compiler.

--- a/examples/flexjs/DataBindingTestbed/build.xml
+++ b/examples/flexjs/DataBindingTestbed/build.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0"?>
+<!--
+
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+-->
+
+
+<project name="databindingexample" default="main" basedir=".">
+    <property name="FLEXJS_HOME" location="../../.."/>
+    <property name="example" value="DataBindingTestbed" />
+    
+    <property file="${FLEXJS_HOME}/env.properties"/>
+    <property environment="env"/>
+    <property file="${FLEXJS_HOME}/build.properties"/>
+    <property name="FLEX_HOME" value="${FLEXJS_HOME}"/>
+    <property name="opt1_arg" value="-js-output-optimization=skipAsCoercions" />
+
+    <include file="${basedir}/../../build_example.xml" />
+    
+    <target name="main" depends="clean,build_example.compile,build_example.compilejs" description="Clean build of ${example}">
+    </target>
+    
+    <target name="clean">
+        <delete dir="${basedir}/bin" failonerror="false" />
+        <delete dir="${basedir}/bin-debug" failonerror="false" />
+        <delete dir="${basedir}/bin-release" failonerror="false" />
+        <delete dir="${basedir}/target" failonerror="false" />
+    </target>
+
+    
+    
+</project>

--- a/examples/flexjs/DataBindingTestbed/pom.xml
+++ b/examples/flexjs/DataBindingTestbed/pom.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.flex.flexjs.examples</groupId>
+    <artifactId>examples-flexjs</artifactId>
+    <version>0.7.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>DataBindingTestbed</artifactId>
+  <version>0.7.0-SNAPSHOT</version>
+  <packaging>swf</packaging>
+
+  <name>Apache Flex - FlexJS: Examples: FlexJS: DataBindingTestbed</name>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.flex.flexjs.compiler</groupId>
+        <artifactId>flexjs-maven-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <mainClass>DataBindingTestbed.mxml</mainClass>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-war-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.adobe.flash.framework</groupId>
+      <artifactId>playerglobal</artifactId>
+      <version>${flash.version}</version>
+      <type>swc</type>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/examples/flexjs/DataBindingTestbed/src/DataBindingTestbed.mxml
+++ b/examples/flexjs/DataBindingTestbed/src/DataBindingTestbed.mxml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+<js:Application xmlns:fx="http://ns.adobe.com/mxml/2009"
+                   xmlns:local="*"
+                   xmlns:js="library://ns.apache.org/flexjs/basic" 
+                   xmlns:models="models.*" 
+                   xmlns:controllers="controllers.*"
+                   
+                   >
+    <js:valuesImpl>
+        <js:SimpleCSSValuesImpl />
+    </js:valuesImpl>
+    <js:initialView>
+        <local:MyInitialView />
+    </js:initialView>
+    <js:model>
+        <models:MyModel />
+    </js:model>
+    <js:beads>
+        <js:CSSFontFaceBead />
+        <js:ViewSourceContextMenuOption />
+    </js:beads>
+</js:Application>

--- a/examples/flexjs/DataBindingTestbed/src/MyInitialView.mxml
+++ b/examples/flexjs/DataBindingTestbed/src/MyInitialView.mxml
@@ -31,6 +31,7 @@ limitations under the License.
 			import org.apache.flex.events.CustomEvent;
 			import org.apache.flex.utils.Timer;
 			import org.apache.flex.events.ValueChangeEvent;
+			import org.apache.flex.html.Label;
 			private static var timer:Timer;
 			
 			private static const STATIC_PRIVATE_CONST :* = "STATIC_PRIVATE_CONST_VAL";
@@ -52,7 +53,6 @@ limitations under the License.
 				var val:uint = uint(timerText);
 				val++;
 				timerText = val.toString();
-			//	trace('updateTimer',val, timerText);
 	
 			}
 			
@@ -81,7 +81,6 @@ limitations under the License.
 				var val:uint = uint(instanceTimerText);
 				val++;
 				instanceTimerText = val.toString();
-			//	trace('updateTimer',val, timerText);
 	
 			}
 			
@@ -93,15 +92,45 @@ limitations under the License.
 					initStaticTimer();
 					trace('initControls');
 					inst_timer = new Timer(1500);
-				inst_timer.addEventListener(Timer.TIMER,updateInstTimer);
-				inst_timer.start();
-				
-				StaticTimer.initStaticTimer();
-				instTimer = new InstanceTimer();
+					inst_timer.addEventListener(Timer.TIMER,updateInstTimer);
+					inst_timer.start();
+					
+					StaticTimer.initStaticTimer();
+					try{
+					  instTimer = new InstanceTimer();
+					} catch (e:Error) {
+						addErrorReport("problem instantiating InstanceTimer ",e);
+					}
+					
+					try {
+						var test:Object = new BindableSubVO1()
+					} catch (e:Error) {
+						addErrorReport("problem instantiating BindableSubVO1 ",e);
+					}
+					try {
+					   test = new BindableSubVO2()
+					} catch (e:Error) {
+						addErrorReport("problem instantiating BindableSubVO2 ",e);
+					}
+					try {
+						test = new BindableSubVO3()
+					} catch (e:Error) {
+						addErrorReport("problem instantiating BindableSubVO3 ",e);
+					}
+					
+					
+			}
+			
+			
+			private function addErrorReport(desc:String,e:Error):void{
+				var label:Label = new Label();
+				label.text = desc +"["+e+"]";
+				errorReporter.addElement(label);
+			
 			}
 			
 			[Bindable]
-			public var instTimer:InstanceTimer ;// = InstanceTimer.getInstance();
+			public var instTimer:InstanceTimer ;
             
 			
 			[Bindable]
@@ -152,60 +181,69 @@ limitations under the License.
             <js:VerticalLayout />
         </js:beads>
 		<js:Label id="testExplanation" text="These examples are mostly intended for FlexJS dev team to verify various binding functionality" />
-        <js:Label id="expressionTest" text="model expression binding (5 sec timer) {MyModel(applicationModel).modelInstanceTime}" />
-		<js:Label id="timerDemo2" width="300" text="{'test local static expression '+timerText}" />
-		<js:Label id="timerDemo" width="300" text="{'test external static expression '+StaticTimer.static_timerText}" />
+        <js:Label id="expressionTest" text="model expression binding [WORKS](5 sec timer) {MyModel(applicationModel).modelInstanceTime}" />
+		<!--<js:Label id="timerDemo2" width="300" text="{'test local static expression '+timerText}" />-->
+		<!--<js:Label id="timerDemo" width="300" text="{'test external static expression '+StaticTimer.static_timerText}" />-->
 		<js:Container width="500">
 			<js:beads>
 				<js:HorizontalLayout />
 			</js:beads>
-			<js:Label id="timerDemoSB1" text="test local static simplebinding" />
-			<js:Label id="timerDemoSB2" text="{timerText}" />
+			<js:Label id="timerDemoSB1" text="test local static simplebinding [BROKEN]" />
+			<!--<js:Label id="timerDemoSB2" text="{timerText}" />-->
 		</js:Container>		
 		<js:Container width="500">
 			<js:beads>
 				<js:HorizontalLayout />
 			</js:beads>
-			<js:Label id="timerDemoSB3"  text="test external static simplebinding" />
-			<js:Label id="timerDemoSB4"  text="{StaticTimer.static_timerText}" />
+			<js:Label id="timerDemoSB3"  text="test external static simplebinding [BROKEN]" />
+			<!--<js:Label id="timerDemoSB4"  text="{StaticTimer.static_timerText}" />-->
 		</js:Container>
 		<js:Container width="500">
 			<js:beads>
 				<js:HorizontalLayout />
 			</js:beads>
-			<js:Label id="timerDemoSB5"  text="test internal instance simplebinding" />
+			<js:Label id="timerDemoSB5"  text="test internal instance simplebinding [WORKS]" />
 			<js:Label id="timerDemoSB6"  text="{instanceTimerText}" />
 		</js:Container>
 		<js:Container width="500">
 			<js:beads>
 				<js:VerticalLayout />
 			</js:beads>
-			<js:Label id="staticConstDemo1"  text="{STATIC_PRIVATE_CONST}" />
+			<js:Label text="[BROKEN] 3 examples of binding into local and external static constants"/>
+			<!--<js:Label id="staticConstDemo1"  text="{STATIC_PRIVATE_CONST}" />
 			<js:Label id="staticConstDemo2"  text="{STATIC_PUBLIC_CONST}" />
-			<js:Label id="staticConstDemo3"  text="{StaticTimer.EXTERNAL_STATIC_CONST}" />
+			<js:Label id="staticConstDemo3"  text="{StaticTimer.EXTERNAL_STATIC_CONST}" />-->
 		</js:Container>
 		<js:Container width="500">
 			<js:beads>
 				<js:VerticalLayout />
 			</js:beads>
-			<js:Label id="instConstDemo1"  text="{INSTANCE_PRIVATE_CONST}" />
-			<js:Label id="instConstDemo2"  text="{INSTANCE_PUBLIC_CONST}" />
+			<js:Label text="[BROKEN] 2 examples of binding into local instance constants"/>
+			<!--<js:Label id="instConstDemo1"  text="{INSTANCE_PRIVATE_CONST}" />
+			<js:Label id="instConstDemo2"  text="{INSTANCE_PUBLIC_CONST}" />-->
 		</js:Container>
 		<js:Container width="500">
 			<js:beads>
 				<js:HorizontalLayout />
 			</js:beads>
-			<js:Label id="timerDemoSB7"  text="test nested instance timercount" />
+			<js:Label id="timerDemoSB7"  text="test nested instance timercount [BROKEN]" />
 			<js:Label id="timerDemoSB8"  text="{instTimer.timerCount}" />
 		</js:Container>
 		<js:Container width="500">
 			<js:beads>
 				<js:VerticalLayout />
 			</js:beads>
+			<js:Label text="[BROKEN] 2 examples of binding into an Unbindable parent (compiler warning, one const binding):"/>
 			<js:Label id="unbindableParentDemo1"  text="{unbindableParentInstance.unbindableField}" />
 			<js:Label id="unbindableParentDemo1b"  text="{unbindableParentInstance.unbindableField2}" />
 			<js:Label id="unbindableParentDemo2"  text="{unbindableParentInstance.UNBINDABLE_CONST_FIELD}" />
 			
+		</js:Container>
+		<js:Container width="500" id="errorReporter">
+			<js:beads>
+				<js:VerticalLayout />
+			</js:beads>
+						
 		</js:Container>
     </js:Container>	
 </js:View>

--- a/examples/flexjs/DataBindingTestbed/src/MyInitialView.mxml
+++ b/examples/flexjs/DataBindingTestbed/src/MyInitialView.mxml
@@ -1,0 +1,211 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+<js:View xmlns:fx="http://ns.adobe.com/mxml/2009"
+				xmlns:js="library://ns.apache.org/flexjs/basic"
+			    initComplete="initControls()">
+    <fx:Script>
+        <![CDATA[
+			import models.MyModel;
+			import bindables.StaticTimer;
+			import bindables.InstanceTimer;
+			import bindables.*;
+			import unbindable.UnbindableParent;
+			
+			import org.apache.flex.events.CustomEvent;
+			import org.apache.flex.utils.Timer;
+			import org.apache.flex.events.ValueChangeEvent;
+			private static var timer:Timer;
+			
+			private static const STATIC_PRIVATE_CONST :* = "STATIC_PRIVATE_CONST_VAL";
+			public static const STATIC_PUBLIC_CONST :String = "STATIC_PUBLIC_CONST_VAL";
+			
+			private const INSTANCE_PRIVATE_CONST :* = "INSTANCE_PRIVATE_CONST_VAL";
+			public const INSTANCE_PUBLIC_CONST :String = "INSTANCE_PUBLIC_CONST_VAL";
+			
+			[Bindable]
+			private static var timerText:String="1";
+			
+			public static function get altTimerText():String {
+				return timerText;
+			}
+						
+			private static var _inited:Boolean;
+			
+			private static function updateTimer(e:Event=null):void{
+				var val:uint = uint(timerText);
+				val++;
+				timerText = val.toString();
+			//	trace('updateTimer',val, timerText);
+	
+			}
+			
+			private static function initStaticTimer():void{
+			if (!_inited) {
+				timer = new Timer(1000);
+				timer.addEventListener(Timer.TIMER,updateTimer);
+				timer.start();
+				_inited = true;
+				trace('initStaticTimer');
+			}
+			}
+			
+			public static var staticMM:MyModel;
+			
+			[Bindable]
+			public static var staticMMBindable:MyModel;
+			
+			
+			private  var inst_timer:Timer;
+			
+			[Bindable]
+            public var instanceTimerText:String ="1";
+			
+			private  function updateInstTimer(e:Event=null):void{
+				var val:uint = uint(instanceTimerText);
+				val++;
+				instanceTimerText = val.toString();
+			//	trace('updateTimer',val, timerText);
+	
+			}
+			
+            
+		
+			private function initControls():void
+			{
+					
+					initStaticTimer();
+					trace('initControls');
+					inst_timer = new Timer(1500);
+				inst_timer.addEventListener(Timer.TIMER,updateInstTimer);
+				inst_timer.start();
+				
+				StaticTimer.initStaticTimer();
+				instTimer = new InstanceTimer();
+			}
+			
+			[Bindable]
+			public var instTimer:InstanceTimer ;// = InstanceTimer.getInstance();
+            
+			
+			[Bindable]
+			public var unbindableParentInstance:UnbindableParent = new UnbindableParent();
+			
+			
+			public var subVO1:BindableSubVO1;
+			public var subVO2:BindableSubVO2;
+			public var subVO3:BindableSubVO3;
+		]]>
+    </fx:Script>
+	<fx:Style>
+		@namespace basic "library://ns.apache.org/flexjs/basic";
+		
+		.output {
+			font-size: 20px;
+		}
+
+        .topContainer {
+            padding: 10px;
+            
+        }
+        .leftSide {
+            vertical-align: top;
+            margin-right: 10px;
+        }
+        
+        .rightSide {
+            vertical-align: top;
+            margin-left: 10px;
+            padding-left: 10px;
+        }
+        
+        .quoteButton {
+            margin-top: 10px;
+            margin-bottom: 10px;
+        }
+	</fx:Style>
+    <js:states>
+        <js:State name="hideAll" />        
+        <js:State name="showAll" />        
+    </js:states>
+    <js:beads>
+        <js:ViewDataBinding/>
+    </js:beads>
+    <js:Container x="0" y="0" className="topContainer" >
+        <js:beads>
+            <js:VerticalLayout />
+        </js:beads>
+		<js:Label id="testExplanation" text="These examples are mostly intended for FlexJS dev team to verify various binding functionality" />
+        <js:Label id="expressionTest" text="model expression binding (5 sec timer) {MyModel(applicationModel).modelInstanceTime}" />
+		<js:Label id="timerDemo2" width="300" text="{'test local static expression '+timerText}" />
+		<js:Label id="timerDemo" width="300" text="{'test external static expression '+StaticTimer.static_timerText}" />
+		<js:Container width="500">
+			<js:beads>
+				<js:HorizontalLayout />
+			</js:beads>
+			<js:Label id="timerDemoSB1" text="test local static simplebinding" />
+			<js:Label id="timerDemoSB2" text="{timerText}" />
+		</js:Container>		
+		<js:Container width="500">
+			<js:beads>
+				<js:HorizontalLayout />
+			</js:beads>
+			<js:Label id="timerDemoSB3"  text="test external static simplebinding" />
+			<js:Label id="timerDemoSB4"  text="{StaticTimer.static_timerText}" />
+		</js:Container>
+		<js:Container width="500">
+			<js:beads>
+				<js:HorizontalLayout />
+			</js:beads>
+			<js:Label id="timerDemoSB5"  text="test internal instance simplebinding" />
+			<js:Label id="timerDemoSB6"  text="{instanceTimerText}" />
+		</js:Container>
+		<js:Container width="500">
+			<js:beads>
+				<js:VerticalLayout />
+			</js:beads>
+			<js:Label id="staticConstDemo1"  text="{STATIC_PRIVATE_CONST}" />
+			<js:Label id="staticConstDemo2"  text="{STATIC_PUBLIC_CONST}" />
+			<js:Label id="staticConstDemo3"  text="{StaticTimer.EXTERNAL_STATIC_CONST}" />
+		</js:Container>
+		<js:Container width="500">
+			<js:beads>
+				<js:VerticalLayout />
+			</js:beads>
+			<js:Label id="instConstDemo1"  text="{INSTANCE_PRIVATE_CONST}" />
+			<js:Label id="instConstDemo2"  text="{INSTANCE_PUBLIC_CONST}" />
+		</js:Container>
+		<js:Container width="500">
+			<js:beads>
+				<js:HorizontalLayout />
+			</js:beads>
+			<js:Label id="timerDemoSB7"  text="test nested instance timercount" />
+			<js:Label id="timerDemoSB8"  text="{instTimer.timerCount}" />
+		</js:Container>
+		<js:Container width="500">
+			<js:beads>
+				<js:VerticalLayout />
+			</js:beads>
+			<js:Label id="unbindableParentDemo1"  text="{unbindableParentInstance.unbindableField}" />
+			<js:Label id="unbindableParentDemo1b"  text="{unbindableParentInstance.unbindableField2}" />
+			<js:Label id="unbindableParentDemo2"  text="{unbindableParentInstance.UNBINDABLE_CONST_FIELD}" />
+			
+		</js:Container>
+    </js:Container>	
+</js:View>

--- a/examples/flexjs/DataBindingTestbed/src/bindables/BindableBaseVO.as
+++ b/examples/flexjs/DataBindingTestbed/src/bindables/BindableBaseVO.as
@@ -1,0 +1,31 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+//  Licensed to the Apache Software Foundation (ASF) under one or more
+//  contributor license agreements.  See the NOTICE file distributed with
+//  this work for additional information regarding copyright ownership.
+//  The ASF licenses this file to You under the Apache License, Version 2.0
+//  (the "License"); you may not use this file except in compliance with
+//  the License.  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+package bindables
+{
+
+	public class BindableBaseVO
+	{
+			
+
+			
+			[Bindable]
+			public var fieldOfBindableBaseVO:String = "fieldOfBindableBaseVO_value";
+
+	}
+}

--- a/examples/flexjs/DataBindingTestbed/src/bindables/BindableSubVO1.as
+++ b/examples/flexjs/DataBindingTestbed/src/bindables/BindableSubVO1.as
@@ -1,0 +1,33 @@
+0.////////////////////////////////////////////////////////////////////////////////
+//
+//  Licensed to the Apache Software Foundation (ASF) under one or more
+//  contributor license agreements.  See the NOTICE file distributed with
+//  this work for additional information regarding copyright ownership.
+//  The ASF licenses this file to You under the Apache License, Version 2.0
+//  (the "License"); you may not use this file except in compliance with
+//  the License.  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+package bindables
+{
+
+	public class BindableSubVO1 extends BindableBaseVO
+	{
+			
+
+			
+			[Bindable]
+			public var fieldOfBindableSubVO1:String = "fieldOfBindableSubVO1_value";
+			
+
+
+	}
+}

--- a/examples/flexjs/DataBindingTestbed/src/bindables/BindableSubVO2.as
+++ b/examples/flexjs/DataBindingTestbed/src/bindables/BindableSubVO2.as
@@ -1,0 +1,33 @@
+0.////////////////////////////////////////////////////////////////////////////////
+//
+//  Licensed to the Apache Software Foundation (ASF) under one or more
+//  contributor license agreements.  See the NOTICE file distributed with
+//  this work for additional information regarding copyright ownership.
+//  The ASF licenses this file to You under the Apache License, Version 2.0
+//  (the "License"); you may not use this file except in compliance with
+//  the License.  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+package bindables
+{
+
+	public class BindableSubVO2 extends UnbindableBaseVO
+	{
+			
+
+			
+			[Bindable]
+			public var fieldofBindableSubVO2:String = "fieldofBindableSubVO2_value";
+			
+
+
+	}
+}

--- a/examples/flexjs/DataBindingTestbed/src/bindables/BindableSubVO3.as
+++ b/examples/flexjs/DataBindingTestbed/src/bindables/BindableSubVO3.as
@@ -1,0 +1,33 @@
+0.////////////////////////////////////////////////////////////////////////////////
+//
+//  Licensed to the Apache Software Foundation (ASF) under one or more
+//  contributor license agreements.  See the NOTICE file distributed with
+//  this work for additional information regarding copyright ownership.
+//  The ASF licenses this file to You under the Apache License, Version 2.0
+//  (the "License"); you may not use this file except in compliance with
+//  the License.  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+package bindables
+{
+
+	public class BindableSubVO3 extends UnbindableIntermediateVO
+	{
+			
+
+			
+			[Bindable]
+			public var fieldofBindableSubVO3:String = "fieldofBindableSubVO3_value";
+			
+
+
+	}
+}

--- a/examples/flexjs/DataBindingTestbed/src/bindables/InstanceTimer.as
+++ b/examples/flexjs/DataBindingTestbed/src/bindables/InstanceTimer.as
@@ -1,0 +1,69 @@
+0.////////////////////////////////////////////////////////////////////////////////
+//
+//  Licensed to the Apache Software Foundation (ASF) under one or more
+//  contributor license agreements.  See the NOTICE file distributed with
+//  this work for additional information regarding copyright ownership.
+//  The ASF licenses this file to You under the Apache License, Version 2.0
+//  (the "License"); you may not use this file except in compliance with
+//  the License.  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+package bindables
+{
+	import org.apache.flex.events.Event;
+
+				import org.apache.flex.utils.Timer;
+			
+	public class InstanceTimer
+	{
+			
+			public function InstanceTimer(){
+				initTimer(1500);
+			}
+			
+			
+			private static var _inst:InstanceTimer;
+			
+			public static function getInstance():InstanceTimer {
+				return _inst || (_inst = new InstanceTimer());
+			
+			}
+			
+			
+			
+			
+			private var timer:Timer;
+						
+			
+			
+			private function updateTimer(e:Event=null):void{
+				timerCount++
+			//	trace('updateTimer',timerCount);
+	
+			}
+			
+			private  function initTimer(val:uint):void{
+
+				timer = new Timer(val);
+				timer.addEventListener(Timer.TIMER,updateTimer);
+				timer.start();
+				trace('init InstanceTimer');
+
+			}
+			
+			[Bindable]
+			public var timerCount:uint = 0;
+			
+			[Bindable]
+			public static var stimerCount:uint = 0;
+
+	}
+}

--- a/examples/flexjs/DataBindingTestbed/src/bindables/StaticTimer.as
+++ b/examples/flexjs/DataBindingTestbed/src/bindables/StaticTimer.as
@@ -1,0 +1,61 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+//  Licensed to the Apache Software Foundation (ASF) under one or more
+//  contributor license agreements.  See the NOTICE file distributed with
+//  this work for additional information regarding copyright ownership.
+//  The ASF licenses this file to You under the Apache License, Version 2.0
+//  (the "License"); you may not use this file except in compliance with
+//  the License.  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+package bindables
+{
+	import org.apache.flex.events.Event;
+
+				import org.apache.flex.utils.Timer;
+	public class StaticTimer
+	{
+	
+			public static const EXTERNAL_STATIC_CONST:String = "EXTERNAL_STATIC_CONST_VAL";
+
+			public function StaticTimer() {
+			//trace("STATICTIMER");
+			}
+			
+			private static var timer:Timer;
+						
+			private static var _inited:Boolean;
+			
+			private static function updateTimer(e:Event=null):void{
+				var val:uint = uint(static_timerText);
+				val++;
+				static_timerText = val.toString();
+			//	trace('updateTimer',val, static_timerText);
+	
+			}
+			
+			public static function initStaticTimer():void{
+			if (!_inited) {
+				timer = new Timer(1000);
+				timer.addEventListener(Timer.TIMER,updateTimer);
+				timer.start();
+				_inited = true;
+				trace('initStaticTimer');
+			}
+			}
+			//[Bindable]
+			public var instBindable:String;
+			
+			[Bindable]
+			public static var static_timerText:String="1";
+
+	}
+}

--- a/examples/flexjs/DataBindingTestbed/src/bindables/UnbindableBaseVO.as
+++ b/examples/flexjs/DataBindingTestbed/src/bindables/UnbindableBaseVO.as
@@ -1,0 +1,31 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+//  Licensed to the Apache Software Foundation (ASF) under one or more
+//  contributor license agreements.  See the NOTICE file distributed with
+//  this work for additional information regarding copyright ownership.
+//  The ASF licenses this file to You under the Apache License, Version 2.0
+//  (the "License"); you may not use this file except in compliance with
+//  the License.  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+package bindables
+{
+
+	public class UnbindableBaseVO
+	{
+			
+
+			
+			public var fieldOfUnbindableBaseVO:String = "fieldOfUnbindableBaseVO_value";
+			
+
+	}
+}

--- a/examples/flexjs/DataBindingTestbed/src/bindables/UnbindableIntermediateVO.as
+++ b/examples/flexjs/DataBindingTestbed/src/bindables/UnbindableIntermediateVO.as
@@ -1,0 +1,31 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+//  Licensed to the Apache Software Foundation (ASF) under one or more
+//  contributor license agreements.  See the NOTICE file distributed with
+//  this work for additional information regarding copyright ownership.
+//  The ASF licenses this file to You under the Apache License, Version 2.0
+//  (the "License"); you may not use this file except in compliance with
+//  the License.  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+package bindables
+{
+
+	public class UnbindableIntermediateVO extends BindableBaseVO
+	{
+			
+
+			
+			public var fieldOfUnbindableIntermediateVO:String = "fieldOfUnbindableIntermediateVO_value";
+			
+
+	}
+}

--- a/examples/flexjs/DataBindingTestbed/src/models/MyModel.as
+++ b/examples/flexjs/DataBindingTestbed/src/models/MyModel.as
@@ -1,0 +1,47 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+//  Licensed to the Apache Software Foundation (ASF) under one or more
+//  contributor license agreements.  See the NOTICE file distributed with
+//  this work for additional information regarding copyright ownership.
+//  The ASF licenses this file to You under the Apache License, Version 2.0
+//  (the "License"); you may not use this file except in compliance with
+//  the License.  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+package models
+{
+	import org.apache.flex.events.Event;
+	import org.apache.flex.events.EventDispatcher;
+	import org.apache.flex.utils.Timer;
+	
+	public class MyModel extends EventDispatcher
+	{
+		public function MyModel()
+		{
+			timer = new Timer(5000);
+			timer.addEventListener(Timer.TIMER, updateInstanceTime);
+			timer.start();
+		}
+		
+		private var timer:Timer;
+		
+		[Bindable]
+		public var modelInstanceTime:uint = 0;
+	
+		
+		private function updateInstanceTime(e:Event):void{
+			modelInstanceTime++;
+		}
+		
+		
+
+	}
+}

--- a/examples/flexjs/DataBindingTestbed/src/unbindable/UnbindableParent.as
+++ b/examples/flexjs/DataBindingTestbed/src/unbindable/UnbindableParent.as
@@ -1,0 +1,38 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+//  Licensed to the Apache Software Foundation (ASF) under one or more
+//  contributor license agreements.  See the NOTICE file distributed with
+//  this work for additional information regarding copyright ownership.
+//  The ASF licenses this file to You under the Apache License, Version 2.0
+//  (the "License"); you may not use this file except in compliance with
+//  the License.  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+package unbindable
+{
+
+	public class UnbindableParent
+	{
+	
+			
+			
+			public static var unbindableStaticField:String = "unbindableStaticField_value";
+			
+			
+			public var unbindableField:String = "unbindableField_value";
+			
+			public var unbindableField2:String = "unbindableField2_value";
+			
+			public const UNBINDABLE_CONST_FIELD:String="UNBINDABLE_CONST_FIELD_VALUE";
+			
+
+	}
+}


### PR DESCRIPTION
As discussed with Alex on the mailing list, this is a new Databinding example that is solely intended to test variations of databinding, to highlight errors. Currently this is two commits ahead of develop. The first one represents the full set of bindings that work across swf, js-debug and js-release after changes to falcon/falcon-jx and to flex-asjs that will be available in two subsequent pull requests.

The most recent commit makes it possible to build and get a report of various problems. All the reported errors and items marked [BROKEN]  will be working after those subsequent PRs. If you uncomment any of the additional labels in MyInitialView.mxml you will likely get either flash runtime errors or js build errors until the other fixes are applied.
